### PR TITLE
ci: replace archived actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -24,12 +24,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: 🦀 Install Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           components: clippy
-          override: true
 
       - name: 📦 Install required cargo
         run: cargo install clippy-sarif sarif-fmt


### PR DESCRIPTION
`actions-rs/*` was archived in 2022 and runs on the deprecated Node 16 runtime (warning annotations now, eventual hard failure). Swaps the Rust toolchain install in the clippy scan job for the maintained `dtolnay/rust-toolchain`.

- channel moves to the ref: `@stable`
- `profile: minimal` and `override: true` are dtolnay defaults, so dropped
- `components: clippy` unchanged

No behaviour change — the clippy SARIF scan runs the same. Verified via this PR's `👓 Scan` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)